### PR TITLE
Change missing admin permission

### DIFF
--- a/Controller/Adminhtml/AbstractUpload.php
+++ b/Controller/Adminhtml/AbstractUpload.php
@@ -98,7 +98,7 @@ abstract class AbstractUpload extends Action
      */
     protected function _isAllowed()
     {
-        return $this->_authorization->isAllowed('SR_CategoryImage::category');
+        return $this->_authorization->isAllowed('Magento_Catalog::categories');
     }
 
     /**


### PR DESCRIPTION
The permission SR_CategoryImage::category is not defined in any acl.xml file.

I suggest using same Magento category save permission as required for other changes in the page - another fix would be creating the acl.xml file.